### PR TITLE
feat: introduce dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: "weekly"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: "weekly"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+  - package-ecosystem: docker
+    directory: build/docker
+    schedule:
+      interval: "weekly"
+    groups:
+      dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Overview

Introduce dependabot maintains dependencies for go-modules/github-actions/docker.

## Reference

https://docs.github.com/ja/code-security/dependabot/working-with-dependabot

---
<details><summary>Japanese</summary>

dependabotを導入しました。
</details>
