### PR TITLE
fix: dependabot's dockerfile path

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,7 @@ updates:
         patterns:
           - "*"
   - package-ecosystem: docker
-    directory: build/docker
+    directory: build
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
## Overview

The dockerfile path of dependabot was invalid and fix it.



---
<details><summary>Japanese</summary>
dependabotにおけるdockerfileのpathがミスってたｍｍ

</details>

