### PR TITLE
feat: .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.gen.sql linguist-generated=true


### PR DESCRIPTION
## Overview

Add `.gitattributes` in order to hide generate file diff.

## Details

`gen.go` is hidden by default.

## Reference

https://git-scm.com/docs/gitattributes

<!-- Optional

---
<details><summary>Japanese</summary>

</details>

-->
