### PR TITLE
feat: make db-sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,10 @@
 ENV=local
 
+# GCP
+PROJECT_ID=days-project
+
 # Spanner
 SPANNER_PORT=9010
-SPANNER_PROJECT_ID=days-project
 SPANNER_INSTANCE=days-instance
 SPANNER_DB=days_local
 SPANNER_EMULATOR_HOST=localhost:9010

--- a/build/db-schema-sync.Dockerfile
+++ b/build/db-schema-sync.Dockerfile
@@ -1,0 +1,26 @@
+ARG GO_VERSION
+
+# ===== build go binary =====
+FROM golang:${GO_VERSION}-alpine3.19 as go-builder
+
+WORKDIR /go/src/github.com/karamaru-alpha/days
+
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+RUN go install github.com/daichirata/hammer
+
+COPY cmd/db-schema-sync cmd/db-schema-sync
+
+RUN CGO_ENABLED=0 go build -o db-schema-sync -trimpath -ldflags '-s -w' cmd/db-schema-sync/main.go
+
+# ==== build docker image ====
+FROM alpine:3.19.1
+
+WORKDIR /usr/src/days
+
+COPY --from=go-builder /go/src/github.com/karamaru-alpha/days/db-schema-sync db-schema-sync
+COPY --from=go-builder /go/bin/hammer /usr/local/bin/hammer
+COPY /db/ddl db/ddl
+
+ENTRYPOINT ["/usr/src/days/db-schema-sync"]

--- a/cmd/db-schema-sync/database/spanner.go
+++ b/cmd/db-schema-sync/database/spanner.go
@@ -1,0 +1,27 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+
+	spanner "cloud.google.com/go/spanner/admin/database/apiv1"
+)
+
+func NewSpannerAdminClient(ctx context.Context) (*spanner.DatabaseAdminClient, error) {
+	cli, err := spanner.NewDatabaseAdminClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("fail to connect to spanner. err: %w", err)
+	}
+	return cli, nil
+}
+
+func DiffSpanner(ctx context.Context, projectID, instance, db, ddlFilePath string) (string, error) {
+	url := fmt.Sprintf("spanner://projects/%s/instances/%s/databases/%s?x-clean-statements=true", projectID, instance, db)
+	output, err := exec.CommandContext(ctx, "hammer", "diff", url, ddlFilePath).CombinedOutput()
+	if err != nil {
+		// outputに標準エラー出力の値が入る
+		return "", fmt.Errorf("fail to get schema diff. output = %s: %w", string(output), err)
+	}
+	return string(output), nil
+}

--- a/cmd/db-schema-sync/main.go
+++ b/cmd/db-schema-sync/main.go
@@ -53,14 +53,14 @@ func cmd() code {
 }
 
 func syncSpannerSchema(ctx context.Context, projectID, instance, db, ddlFilePath, target string) error {
-	slog.Info(fmt.Sprintf("[Spanner (%s)] start to sync.", target))
+	slog.Info(fmt.Sprintf("[Spanner (%s)] start to sync", target))
 
 	diff, err := database.DiffSpanner(ctx, projectID, instance, db, ddlFilePath)
 	if err != nil {
 		return err
 	}
 	if diff == "" {
-		slog.Info(fmt.Sprintf("[Spanner (%s)] no changes.", target))
+		slog.Info(fmt.Sprintf("[Spanner (%s)] no changes", target))
 		return nil
 	}
 
@@ -74,7 +74,7 @@ func syncSpannerSchema(ctx context.Context, projectID, instance, db, ddlFilePath
 		validStatements = append(validStatements, statement)
 	}
 	if len(validStatements) == 0 {
-		slog.Info(fmt.Sprintf("[Spanner (%s)] no changes.", target))
+		slog.Info(fmt.Sprintf("[Spanner (%s)] no changes", target))
 		return nil
 	}
 
@@ -96,7 +96,7 @@ func syncSpannerSchema(ctx context.Context, projectID, instance, db, ddlFilePath
 		return err
 	}
 
-	slog.Info(fmt.Sprintf("[Spanner (%s)] finished to sync.", target))
+	slog.Info(fmt.Sprintf("[Spanner (%s)] finished to sync", target))
 	return nil
 }
 

--- a/cmd/db-schema-sync/main.go
+++ b/cmd/db-schema-sync/main.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"runtime"
+	"strings"
+
+	"cloud.google.com/go/spanner/admin/database/apiv1/databasepb"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/karamaru-alpha/days/cmd/db-schema-sync/database"
+)
+
+type code int
+
+const (
+	success code = 0
+	failure code = 1
+
+	transactionDDLFilePath = "db/ddl/transaction.gen.sql"
+)
+
+func main() {
+	os.Exit(int(cmd()))
+}
+
+func cmd() code {
+	// Transaction Spanner
+	transactionProjectID := os.Getenv("PROJECT_ID")
+	transactionInstance := os.Getenv("SPANNER_INSTANCE")
+	transactionDB := os.Getenv("SPANNER_DB")
+
+	ctx := context.Background()
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() (err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				err = recoverError(r)
+			}
+		}()
+		return syncSpannerSchema(ctx, transactionProjectID, transactionInstance, transactionDB, transactionDDLFilePath, "transaction")
+	})
+
+	if err := eg.Wait(); err != nil {
+		slog.Error(fmt.Sprintf("fail to sync schema err = %+v", err))
+		return failure
+	}
+
+	return success
+}
+
+func syncSpannerSchema(ctx context.Context, projectID, instance, db, ddlFilePath, target string) error {
+	slog.Info(fmt.Sprintf("[Spanner (%s)] start to sync.", target))
+
+	diff, err := database.DiffSpanner(ctx, projectID, instance, db, ddlFilePath)
+	if err != nil {
+		return err
+	}
+	if diff == "" {
+		slog.Info(fmt.Sprintf("[Spanner (%s)] no changes.", target))
+		return nil
+	}
+
+	diffStatements := strings.Split(diff, ";")
+	validStatements := make([]string, 0, len(diffStatements))
+	for _, statement := range diffStatements {
+		statement = strings.TrimSpace(statement)
+		if statement == "" {
+			continue
+		}
+		validStatements = append(validStatements, statement)
+	}
+	if len(validStatements) == 0 {
+		slog.Info(fmt.Sprintf("[Spanner (%s)] no changes.", target))
+		return nil
+	}
+
+	spannerAdminClient, err := database.NewSpannerAdminClient(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := spannerAdminClient.Close(); err != nil {
+			slog.Error(fmt.Sprintf("fail to close spanner connection. err = %+v", err))
+		}
+	}()
+
+	slog.Info(fmt.Sprintf("[Spanner (%s)] execute sync. ddl = %v", target, validStatements))
+	if _, err := spannerAdminClient.UpdateDatabaseDdl(ctx, &databasepb.UpdateDatabaseDdlRequest{
+		Database:   fmt.Sprintf("projects/%s/instances/%s/databases/%s", projectID, instance, db),
+		Statements: validStatements,
+	}); err != nil {
+		return err
+	}
+
+	slog.Info(fmt.Sprintf("[Spanner (%s)] finished to sync.", target))
+	return nil
+}
+
+func recoverError(r any) error {
+	var stacktrace string
+	for depth := 0; ; depth++ {
+		_, file, line, ok := runtime.Caller(depth)
+		if !ok {
+			break
+		}
+		stacktrace += fmt.Sprintf("        %v:%d\n", file, line)
+	}
+	return fmt.Errorf("panic occurred. recovered = %v\nstacktrace = %s", r, stacktrace)
+}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/scylladb/go-set v1.0.2
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/fx v1.21.1
+	go.uber.org/zap v1.26.0
 	golang.org/x/net v0.25.0
 	golang.org/x/sync v0.7.0
 	golang.org/x/tools v0.21.0
@@ -23,6 +24,8 @@ require (
 	cloud.google.com/go/auth v0.4.1 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.2 // indirect
 	cloud.google.com/go/compute/metadata v0.3.0 // indirect
+	cloud.google.com/go/iam v1.1.8 // indirect
+	cloud.google.com/go/longrunning v0.5.7 // indirect
 	github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp v1.5.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.2.0 // indirect
@@ -54,7 +57,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.24.0 // indirect
 	go.uber.org/dig v1.17.1 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
-	go.uber.org/zap v1.26.0 // indirect
 	golang.org/x/crypto v0.23.0 // indirect
 	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/oauth2 v0.20.0 // indirect
@@ -63,6 +65,7 @@ require (
 	golang.org/x/time v0.5.0 // indirect
 	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 // indirect
 	google.golang.org/api v0.180.0 // indirect
+	google.golang.org/genproto v0.0.0-20240401170217-c3f982113cda // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240513163218-0867130af1f8 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240513163218-0867130af1f8 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect


### PR DESCRIPTION
## Overview

Implement `make db-sync` in order to sync schema of spanner(transaction).

## Details

TODO
- another data schema sync (master/admin...)

## References
https://github.com/daichirata/hammer

---
<details><summary>Japanese</summary>

宣言的スキーマの同期を行いました。
現状spannerだけですが、マスタデータとかでMySQLが必要になればそちらも実装します。

</details>
